### PR TITLE
fix: add support to install extra dependencies in poetry

### DIFF
--- a/examples/numalogic-simple-pipeline/Dockerfile
+++ b/examples/numalogic-simple-pipeline/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
 
 WORKDIR $PYSETUP_PATH
 COPY ./pyproject.toml ./poetry.lock $PYSETUP_PATH
-RUN poetry install --without dev --no-cache --no-root && \
+RUN poetry install --all-extras --without dev --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 
 ADD . /app


### PR DESCRIPTION
Signed-off-by: s0nicboOm <i.kushalbatra@gmail.com>

Explain what this PR does:
This PR makes sure that we are installing mlflow in Dockerfile. Using `--all-extra` to accomplish this.

