### PR TITLE
fix: load model from production and/or staging stage

### DIFF
--- a/numalogic/registry/mlflow_registry.py
+++ b/numalogic/registry/mlflow_registry.py
@@ -146,6 +146,7 @@ class MLflowRegistry(ArtifactManager):
                 # No model exists in PRODUCTION or STAGING
                 else:
                     raise Exception("No model in Production or staging")
+
                 model = self.handler.load_model(
                     model_uri=f"models:/{model_key}/{version_info.version}"
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numalogic"
-version = "0.3.5"
+version = "0.3.6"
 description = "Collection of operational Machine Learning models and tools."
 authors = ["Numalogic Developers"]
 packages = [{ include = "numalogic" }]

--- a/tests/registry/_mlflow_utils.py
+++ b/tests/registry/_mlflow_utils.py
@@ -160,7 +160,7 @@ def mock_get_model_version(*_, **__):
     return [
         ModelVersion(
             creation_timestamp=1653402941169,
-            current_stage="Production",
+            current_stage="Staging",
             description="",
             last_updated_timestamp=1653402941191,
             name="test::error",


### PR DESCRIPTION
Loading of model from Production or Staging Environment in mlflow_registry.

NOTE: If model is not present in Staging or Production we throw an exception.