### PR TITLE
fix: Tanhscaler nan output for constant feature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numalogic"
-version = "0.3.6"
+version = "0.3.7"
 description = "Collection of operational Machine Learning models and tools."
 authors = ["Numalogic Developers"]
 packages = [{ include = "numalogic" }]

--- a/tests/preprocess/test_transformer.py
+++ b/tests/preprocess/test_transformer.py
@@ -42,6 +42,26 @@ class TestTransformers(unittest.TestCase):
         assert_array_less(x_scaled, np.ones_like(x_scaled))
         assert_array_less(np.zeros_like(x_scaled), x_scaled)
 
+    def test_tanh_scaler_3(self):
+        x = np.random.randn(5, 3)
+        x[:, 1] = np.zeros(5)
+
+        scaler = TanhScaler()
+
+        x_scaled = scaler.fit_transform(x)
+        self.assertFalse(np.isnan(x_scaled[:, 1]).all())
+        assert_array_less(x_scaled, np.ones_like(x_scaled))
+        assert_array_less(np.zeros_like(x_scaled), x_scaled)
+
+    def test_tanh_scaler_nan(self):
+        x = np.random.randn(5, 3)
+        x[:, 1] = np.zeros(5)
+
+        scaler = TanhScaler(eps=0.0)
+
+        x_scaled = scaler.fit_transform(x)
+        self.assertTrue(np.isnan(x_scaled[:, 1]).all())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When the variance of input time series is zero, then we encounter a division by zero problem.
This led to NaN outputs.

This change checks if a feature is indistinguishable from a constant feature or not. If yes, then set the std as 1.0 for that feature. This will stop the feature from getting scaled by it's zero variance.