### PR TITLE
chore!: Auto detect instance type while mlflow model save

### DIFF
--- a/docs/ml-flow.md
+++ b/docs/ml-flow.md
@@ -23,21 +23,21 @@ Numalogic provides `MLflowRegistry`, to save and load models to/from MLflow.
 
 Here, `tracking_uri` is the uri where mlflow server is running. The `static_keys` and `dynamic_keys` are used to form a unique key for the model.
 
-The `primary_artifact` would be the main model, and `secondary_artifacts` can be used to save any pre-processing models like scalers.
-
+The `artifact` would be the model or transformer object that needs to be saved.
+A dictionary of metadata can also be saved along with the artifact.
 ```python
 from numalogic.registry import MLflowRegistry
+from numalogic.models.autoencoder.variants import VanillaAE
+
+model = VanillaAE(seq_len=10)
 
 # static and dynamic keys are used to look up a model
-static_keys = ["synthetic", "3ts"]
-dynamic_keys = ["minmaxscaler", "sparseconv1d"]
+static_keys = ["model", "autoencoder"]
+dynamic_keys = ["vanilla", "seq10"]
 
-registry = MLflowRegistry(tracking_uri="http://0.0.0.0:5000", artifact_type="pytorch")
+registry = MLflowRegistry(tracking_uri="http://0.0.0.0:5000")
 registry.save(
-    skeys=static_keys,
-    dkeys=dynamic_keys,
-    primary_artifact=model,
-    secondary_artifacts={"preproc": scaler},
+    skeys=static_keys, dkeys=dynamic_keys, artifact=model, seq_len=10, lr=0.001
 )
 ```
 
@@ -46,10 +46,19 @@ registry.save(
 Once, the models are save to MLflow, the `load` function of `MLflowRegistry` can be used to load the model.
 
 ```python
+from numalogic.registry import MLflowRegistry
+
+static_keys = ["model", "autoencoder"]
+dynamic_keys = ["vanilla", "seq10"]
+
 registry = MLflowRegistry(tracking_uri="http://0.0.0.0:8080")
-artifact_dict = registry.load(skeys=static_keys, dkeys=dynamic_keys)
-scaler = artifact_dict["secondary_artifacts"]["preproc"]
-model = artifact_dict["primary_artifact"]
+artifact_data = registry.load(
+    skeys=static_keys, dkeys=dynamic_keys, artifact_type="pytorch"
+)
+
+# get the model and metadata
+model = artifact_data.artifact
+model_metadata = artifact_data.metadata
 ```
 
 For more details, please refer to [MLflow Model Registry](https://www.mlflow.org/docs/latest/model-registry.html#)

--- a/numalogic/registry/mlflow_registry.py
+++ b/numalogic/registry/mlflow_registry.py
@@ -145,6 +145,18 @@ class MLflowRegistry(ArtifactManager):
         version: str = None,
         artifact_type: str = "pytorch",
     ) -> Optional[ArtifactData]:
+        """
+        Load the artifact from the registry. The artifact is loaded from the cache if available.
+        Args:
+            skeys: Static keys
+            dkeys: Dynamic keys
+            latest: Load the latest version of the model (default = True)
+            version: Version of the model to load (default = None)
+            artifact_type: Type of the artifact to load (default = "pytorch")
+
+        Returns:
+            The loaded ArtifactData object if available otherwise None
+        """
         model_key = self.construct_key(skeys, dkeys)
 
         if (latest and version) or (not latest and not version):

--- a/numalogic/tools/types.py
+++ b/numalogic/tools/types.py
@@ -18,8 +18,8 @@ from sklearn.base import BaseEstimator
 from torch import nn
 
 artifact_t = TypeVar("artifact_t", bound=Union[nn.Module, BaseEstimator])
-META_T = TypeVar("META_T", bound=dict[str, Union[str, list, dict]])
-META_VT = TypeVar("META_VT", bound=Union[str, list, dict])
+META_T = TypeVar("META_T", bound=dict[str, Union[str, float, int, list, dict]])
+META_VT = TypeVar("META_VT", bound=Union[str, int, float, list, dict])
 EXTRA_T = TypeVar("EXTRA_T", bound=dict[str, Union[str, list, dict]])
 redis_client_t = TypeVar("redis_client_t", bound=AbstractRedis, covariant=True)
 KEYS = TypeVar("KEYS", bound=Sequence[str], covariant=True)

--- a/numalogic/tools/types.py
+++ b/numalogic/tools/types.py
@@ -17,9 +17,9 @@ from redis.client import AbstractRedis
 from sklearn.base import BaseEstimator
 from torch import nn
 
-artifact_t = TypeVar("artifact_t", bound=Union[nn.Module, BaseEstimator])
+artifact_t = TypeVar("artifact_t", bound=Union[nn.Module, BaseEstimator], covariant=True)
 META_T = TypeVar("META_T", bound=dict[str, Union[str, float, int, list, dict]])
-META_VT = TypeVar("META_VT", bound=Union[str, int, float, list, dict])
+META_VT = TypeVar("META_VT", str, int, float, list, dict)
 EXTRA_T = TypeVar("EXTRA_T", bound=dict[str, Union[str, list, dict]])
 redis_client_t = TypeVar("redis_client_t", bound=AbstractRedis, covariant=True)
 KEYS = TypeVar("KEYS", bound=Sequence[str], covariant=True)

--- a/poetry.lock
+++ b/poetry.lock
@@ -3648,14 +3648,14 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
 name = "sympy"
-version = "1.11.1"
+version = "1.12"
 description = "Computer algebra system (CAS) in Python"
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "sympy-1.11.1-py3-none-any.whl", hash = "sha256:938f984ee2b1e8eae8a07b884c8b7a1146010040fccddc6539c54f401c8f6fcf"},
-    {file = "sympy-1.11.1.tar.gz", hash = "sha256:e32380dce63cb7c0108ed525570092fd45168bdae2faa17e528221ef72e88658"},
+    {file = "sympy-1.12-py3-none-any.whl", hash = "sha256:c3588cd4295d0c0f603d0f2ae780587e64e2efeedb3521e46b9bb1d08d184fa5"},
+    {file = "sympy-1.12.tar.gz", hash = "sha256:ebf595c8dac3e0fdc4152c51878b498396ec7f30e7a914d6071e674d49420fb8"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numalogic"
-version = "0.4.dev5"
+version = "0.4.a0"
 description = "Collection of operational Machine Learning models and tools."
 authors = ["Numalogic Developers"]
 packages = [{ include = "numalogic" }]

--- a/tests/registry/test_mlflow_registry.py
+++ b/tests/registry/test_mlflow_registry.py
@@ -10,7 +10,7 @@ from mlflow.store.entities import PagedList
 from sklearn.ensemble import RandomForestRegressor
 
 from numalogic.models.autoencoder.variants import VanillaAE
-from numalogic.registry import MLflowRegistry
+from numalogic.registry import MLflowRegistry, ArtifactData
 from numalogic.registry.mlflow_registry import ModelStage
 from numalogic.tools.exceptions import ModelVersionError
 from tests.registry._mlflow_utils import (
@@ -327,6 +327,16 @@ class TestMLflow(unittest.TestCase):
         data = ml.load(skeys=self.skeys, dkeys=self.dkeys, artifact_type="pytorch")
         with freeze_time("2022-05-24 10:30:00"):
             self.assertFalse(ml.is_artifact_stale(data, 12))
+
+    def test_no_cache(self):
+        registry = MLflowRegistry(TRACKING_URI)
+        self.assertIsNone(
+            registry._save_in_cache(
+                "key", ArtifactData(artifact=self.model, extras={}, metadata={})
+            )
+        )
+        self.assertIsNone(registry._load_from_cache("key"))
+        self.assertIsNone(registry._clear_cache("key"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Helps for a better config-driven registry instance creation.

- Avoid specifying mlflow instance type in the constructor
- Detect the correct handler during save
- Specify artifact type during load
- Update docs