### PR TITLE
fix (RedisRegistry): avoid overwriting cache with the same key during load 

### DIFF
--- a/numalogic/registry/artifact.py
+++ b/numalogic/registry/artifact.py
@@ -48,6 +48,8 @@ class ArtifactManager(Generic[KEYS, A_D]):
         uri: server/connection uri
     """
 
+    _STORETYPE = "registry"
+
     __slots__ = ("uri",)
 
     def __init__(self, uri: str):
@@ -136,6 +138,8 @@ class ArtifactCache(Generic[M_K, A_D]):
         cachesize: size of the cache
         ttl: time to live for each item in the cache
     """
+
+    _STORETYPE = "cache"
 
     __slots__ = ("_cachesize", "_ttl")
 

--- a/numalogic/registry/dynamodb_registry.py
+++ b/numalogic/registry/dynamodb_registry.py
@@ -1,3 +1,14 @@
+# Copyright 2022 The Numaproj Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import time
 from typing import Any, Optional

--- a/numalogic/registry/localcache.py
+++ b/numalogic/registry/localcache.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 from collections.abc import KeysView
+from copy import deepcopy
 from typing import Optional
 
 from cachetools import TTLCache
@@ -62,6 +63,7 @@ class LocalLRUCache(ArtifactCache, metaclass=Singleton):
             key: The key of the artifact to save.
             artifact: The artifact data instance to save.
         """
+        artifact = deepcopy(artifact)
         artifact.extras["source"] = self._STORETYPE
         self.__cache[key] = artifact
 

--- a/numalogic/registry/localcache.py
+++ b/numalogic/registry/localcache.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import KeysView
 from copy import deepcopy
 from typing import Optional
 
@@ -85,6 +84,6 @@ class LocalLRUCache(ArtifactCache, metaclass=Singleton):
         """Clears the whole cache."""
         self.__cache.clear()
 
-    def keys(self) -> KeysView[str]:
+    def keys(self) -> list[str]:
         """Returns the current keys of the cache."""
-        return self.__cache.keys()
+        return list(_key for _key in self.__cache)

--- a/numalogic/registry/localcache.py
+++ b/numalogic/registry/localcache.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import KeysView
 from typing import Optional
 
 from cachetools import TTLCache
@@ -34,14 +35,54 @@ class LocalLRUCache(ArtifactCache, metaclass=Singleton):
         if not self.__cache:
             self.__cache = TTLCache(maxsize=cachesize, ttl=ttl)
 
-    def load(self, artifact_key: str) -> ArtifactData:
+    def __contains__(self, artifact_key: str) -> bool:
+        """Check if an artifact is in the cache."""
+        return artifact_key in self.__cache
+
+    def load(self, artifact_key: str) -> Optional[ArtifactData]:
+        """
+        Load an artifact from the cache.
+
+        Args:
+        ----
+            artifact_key: The key of the artifact to load.
+
+        Returns
+        -------
+            The artifact data instance if found, None otherwise.
+        """
         return self.__cache.get(artifact_key)
 
     def save(self, key: str, artifact: ArtifactData) -> None:
+        """
+        Save an artifact to the cache.
+
+        Args:
+        ----
+            key: The key of the artifact to save.
+            artifact: The artifact data instance to save.
+        """
+        artifact.extras["source"] = self._STORETYPE
         self.__cache[key] = artifact
 
     def delete(self, key: str) -> Optional[ArtifactData]:
+        """
+        Delete an artifact from the cache.
+
+        Args:
+        ----
+            key: The key of the artifact to delete.
+
+        Returns
+        -------
+            The deleted artifact data instance if found, None otherwise.
+        """
         return self.__cache.pop(key, default=None)
 
     def clear(self) -> None:
+        """Clears the whole cache."""
         self.__cache.clear()
+
+    def keys(self) -> KeysView[str]:
+        """Returns the current keys of the cache."""
+        return self.__cache.keys()

--- a/numalogic/registry/redis_registry.py
+++ b/numalogic/registry/redis_registry.py
@@ -94,6 +94,7 @@ class RedisRegistry(ArtifactManager):
 
     def _save_in_cache(self, key: str, artifact_data: ArtifactData) -> None:
         if self.cache_registry:
+            _LOGGER.debug("Saving artifact in cache with key: %s", key)
             self.cache_registry.save(key, artifact_data)
 
     def _clear_cache(self, key: Optional[str] = None) -> Optional[ArtifactData]:
@@ -150,7 +151,7 @@ class RedisRegistry(ArtifactManager):
         if not self.client.exists(latest_key):
             raise ModelKeyNotFound(f"latest key: {latest_key}, Not Found !!!")
         model_key = self.client.get(latest_key)
-        _LOGGER.info("latest key, %s, is pointing to the key : %s", latest_key, model_key)
+        _LOGGER.debug("latest key, %s, is pointing to the key : %s", latest_key, model_key)
         return (
             self.__load_version_artifact(version=self.get_version(model_key.decode()), key=key),
             False,
@@ -170,7 +171,7 @@ class RedisRegistry(ArtifactManager):
         new_version_key = self.__construct_version_key(key, version)
         latest_key = self.__construct_latest_key(key)
         pipe.set(name=latest_key, value=new_version_key)
-        _LOGGER.info("Setting latest key : %s ,to this new key = %s", latest_key, new_version_key)
+        _LOGGER.debug("Setting latest key : %s ,to this new key = %s", latest_key, new_version_key)
         serialized_metadata = ""
         if metadata:
             serialized_metadata = dumps(deserialized_object=metadata)

--- a/numalogic/registry/redis_registry.py
+++ b/numalogic/registry/redis_registry.py
@@ -1,3 +1,14 @@
+# Copyright 2022 The Numaproj Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import time
 from datetime import datetime, timedelta

--- a/numalogic/registry/redis_registry.py
+++ b/numalogic/registry/redis_registry.py
@@ -18,7 +18,7 @@ class RedisRegistry(ArtifactManager):
 
     Args:
     ----
-        client: Take in the reids client already established/created
+        client: Take in the redis client already established/created
         ttl: Total Time to Live (in seconds) for the key when saving in redis (dafault = 604800)
         cache_registry: Cache registry to use (default = None).
 
@@ -260,7 +260,7 @@ class RedisRegistry(ArtifactManager):
         version = 0
         try:
             if self.client.exists(latest_key):
-                _LOGGER.debug("Latest key exists for the model")
+                _LOGGER.debug("Latest key: %s exists for the model", latest_key)
                 version_key = self.client.get(name=latest_key)
                 version = int(self.get_version(version_key.decode())) + 1
             with self.client.pipeline() as pipe:

--- a/numalogic/tools/data.py
+++ b/numalogic/tools/data.py
@@ -168,11 +168,11 @@ class StreamingDataset(IterableDataset):
             start = idx.start or 0
             stop = min(idx.stop, raw_data_size) if idx.stop else raw_data_size
             for i in range(start, stop - self._seq_len + 1):
-                output.append(self._data[i: (i + self._seq_len)])
+                output.append(self._data[i : (i + self._seq_len)])
             return np.stack(output)
         if idx >= len(self):
             raise IndexError(f"{idx} out of bound!")
-        return self._data[idx: idx + self._seq_len]
+        return self._data[idx : idx + self._seq_len]
 
 
 class TimeseriesDataModule(pl.LightningDataModule):

--- a/numalogic/tools/data.py
+++ b/numalogic/tools/data.py
@@ -168,11 +168,11 @@ class StreamingDataset(IterableDataset):
             start = idx.start or 0
             stop = min(idx.stop, raw_data_size) if idx.stop else raw_data_size
             for i in range(start, stop - self._seq_len + 1):
-                output.append(self._data[i : (i + self._seq_len)])
+                output.append(self._data[i: (i + self._seq_len)])
             return np.stack(output)
         if idx >= len(self):
             raise IndexError(f"{idx} out of bound!")
-        return self._data[idx : idx + self._seq_len]
+        return self._data[idx: idx + self._seq_len]
 
 
 class TimeseriesDataModule(pl.LightningDataModule):

--- a/tests/registry/test_cache.py
+++ b/tests/registry/test_cache.py
@@ -27,9 +27,11 @@ class TestLocalLRUCache(unittest.TestCase):
 
         self.assertIsNone(cache_registry.load("m1"))
         self.assertIsInstance(cache_registry.load("m2"), ArtifactData)
-        self.assertIsInstance(cache_registry.load("m3"), ArtifactData)
         self.assertEqual(2, cache_registry.cachesize)
         self.assertEqual(1, cache_registry.ttl)
+        self.assertTrue("m2" in cache_registry)
+        self.assertTrue("m3" in cache_registry)
+        self.assertListEqual(["m2", "m3"], cache_registry.keys())
 
     def test_cache_overwrite(self):
         cache_registry = LocalLRUCache(cachesize=2, ttl=1)

--- a/tests/registry/test_cache.py
+++ b/tests/registry/test_cache.py
@@ -41,7 +41,7 @@ class TestLocalLRUCache(unittest.TestCase):
         )
 
         loaded_artifact = cache_registry.load("m1")
-        self.assertDictEqual({"version": "2"}, loaded_artifact.extras)
+        self.assertDictEqual({"version": "2", "source": "cache"}, loaded_artifact.extras)
 
     def test_cache_ttl(self):
         cache_registry = LocalLRUCache(cachesize=2, ttl=1)

--- a/tests/registry/test_redis_registry.py
+++ b/tests/registry/test_redis_registry.py
@@ -1,3 +1,5 @@
+import logging
+import time
 import unittest
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
@@ -12,6 +14,8 @@ from numalogic.models.autoencoder.variants import VanillaAE
 from numalogic.registry import RedisRegistry, LocalLRUCache, ArtifactData
 from numalogic.tools.exceptions import ModelKeyNotFound, RedisRegistryError
 
+logging.basicConfig(level=logging.DEBUG)
+
 
 class TestRedisRegistry(unittest.TestCase):
     @classmethod
@@ -25,7 +29,7 @@ class TestRedisRegistry(unittest.TestCase):
         cls.redis_client = fakeredis.FakeStrictRedis(server=server, decode_responses=False)
 
     def setUp(self):
-        self.cache = LocalLRUCache(cachesize=4, ttl=300)
+        self.cache = LocalLRUCache(cachesize=4, ttl=1)
         self.registry = RedisRegistry(
             client=self.redis_client,
             cache_registry=self.cache,
@@ -162,19 +166,29 @@ class TestRedisRegistry(unittest.TestCase):
         with self.assertRaises(ModelKeyNotFound):
             self.registry.load(skeys=self.skeys, dkeys=self.dkeys)
 
-    def test_load_model_when_model_stale(self):
-        with self.assertRaises(ModelKeyNotFound):
-            version = self.registry.save(
-                skeys=self.skeys, dkeys=self.dkeys, artifact=self.pytorch_model
-            )
-            self.registry.delete(skeys=self.skeys, dkeys=self.dkeys, version=str(version))
-            self.registry.load(skeys=self.skeys, dkeys=self.dkeys)
+    def test_load_model_twice(self):
+        with freeze_time(datetime.today() - timedelta(days=5)):
+            self.registry.save(skeys=self.skeys, dkeys=self.dkeys, artifact=self.pytorch_model)
+
+        artifact_data_1 = self.registry.load(skeys=self.skeys, dkeys=self.dkeys)
+        artifact_data_2 = self.registry.load(skeys=self.skeys, dkeys=self.dkeys)
+        self.assertTrue(self.registry.is_artifact_stale(artifact_data_1, 4))
+        self.assertEqual("registry", artifact_data_1.extras["source"])
+        self.assertEqual("cache", artifact_data_2.extras["source"])
+
+    def test_cache_ttl(self):
+        self.registry.save(skeys=self.skeys, dkeys=self.dkeys, artifact=self.pytorch_model)
+        artifact_data_1 = self.registry.load(skeys=self.skeys, dkeys=self.dkeys)
+        time.sleep(1)
+        artifact_data_2 = self.registry.load(skeys=self.skeys, dkeys=self.dkeys)
+        self.assertEqual("registry", artifact_data_1.extras["source"])
+        self.assertEqual("registry", artifact_data_2.extras["source"])
 
     def test_delete_version(self):
+        version = self.registry.save(
+            skeys=self.skeys, dkeys=self.dkeys, artifact=self.pytorch_model
+        )
         with self.assertRaises(ModelKeyNotFound):
-            version = self.registry.save(
-                skeys=self.skeys, dkeys=self.dkeys, artifact=self.pytorch_model
-            )
             self.registry.delete(skeys=self.skeys, dkeys=self.dkeys, version=str(version))
             self.registry.load(skeys=self.skeys, dkeys=self.dkeys)
 


### PR DESCRIPTION
- fix cache key overwrite issue which caused a stale model to persist for a long time
- Save sourcetype in artifact data extras to be used for other logic
- Improve docs