### PR TITLE
perf: improve serialization performance

### DIFF
--- a/numalogic/registry/_serialize.py
+++ b/numalogic/registry/_serialize.py
@@ -1,14 +1,25 @@
 import io
+import pickle
+from typing import Union
+
 import torch
 
-
-# TODO: ADD other techniques and support for other serialization techniques
-def dumps(deserialized_object):
-    buf = io.BytesIO()
-    torch.save(deserialized_object, buf)
-    return buf.getvalue()
+from numalogic.tools.types import artifact_t, state_dict_t
 
 
-def loads(serialized_object):
+def dumps(
+    deserialized_object: Union[artifact_t, state_dict_t],
+    pickle_protocol: int = pickle.HIGHEST_PROTOCOL,
+) -> bytes:
+    buffer = io.BytesIO()
+    torch.save(deserialized_object, buffer, pickle_protocol=pickle_protocol)
+    serialized_obj = buffer.getvalue()
+    buffer.close()
+    return serialized_obj
+
+
+def loads(serialized_object: bytes) -> Union[artifact_t, state_dict_t]:
     buffer = io.BytesIO(serialized_object)
-    return torch.load(buffer)
+    deserialized_obj = torch.load(buffer)
+    buffer.close()
+    return deserialized_obj

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numalogic"
-version = "0.6.dev0"
+version = "0.6.dev1"
 description = "Collection of operational Machine Learning models and tools."
 authors = ["Numalogic Developers"]
 packages = [{ include = "numalogic" }]


### PR DESCRIPTION
- close the buffer
- use highest pickle protocol by default
- benchmarking in unit tests


|   Change	|   Improvement	|
|---	|---	|
|  Closing buffer 	|   3.2%	|
|  Protocol update 	|   15.5%	|