### PR TITLE
Fix: Get metrics from _conf.metrics on Trainer to avoid issue with Flattening the matrix

### DIFF
--- a/numalogic/udfs/trainer/_base.py
+++ b/numalogic/udfs/trainer/_base.py
@@ -219,7 +219,7 @@ class TrainerUDF(NumalogicUDF):
 
         # Construct feature array
         x_train, nan_counter, inf_counter = self.get_feature_arr(
-            df, payload.metrics, max_value_map=_conf.numalogic_conf.trainer.max_value_map
+            df, _conf.metrics, max_value_map=_conf.numalogic_conf.trainer.max_value_map
         )
         _add_summary(
             summary=NAN_SUMMARY,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numalogic"
-version = "0.6.2"
+version = "0.6.3"
 description = "Collection of operational Machine Learning models and tools."
 authors = ["Numalogic Developers"]
 packages = [{ include = "numalogic" }]

--- a/tests/udfs/test_trainer.py
+++ b/tests/udfs/test_trainer.py
@@ -87,7 +87,9 @@ class TestDruidTrainerUDF(unittest.TestCase):
                                 conf={"seq_len": 12, "n_features": 2},
                             ),
                             preprocess=[ModelInfo(name="LogTransformer", stateful=True, conf={})],
-                            trainer=TrainerConf(pltrainer_conf=LightningTrainerConf(max_epochs=1)),
+                            trainer=TrainerConf(
+                                pltrainer_conf=LightningTrainerConf(accelerator="cpu", max_epochs=1)
+                            ),
                         ),
                     )
                 }
@@ -122,6 +124,7 @@ class TestDruidTrainerUDF(unittest.TestCase):
                 ml_pipelines={
                     "pipeline1": MLPipelineConf(
                         pipeline_id="pipeline1",
+                        metrics=["failed", "degraded"],
                         numalogic_conf=NumalogicConf(
                             model=ModelInfo(
                                 name="VanillaAE", conf={"seq_len": 12, "n_features": 2}
@@ -154,6 +157,7 @@ class TestDruidTrainerUDF(unittest.TestCase):
                 ml_pipelines={
                     "pipeline1": MLPipelineConf(
                         pipeline_id="pipeline1",
+                        metrics=["failed", "degraded"],
                         numalogic_conf=NumalogicConf(
                             model=ModelInfo(
                                 name="VanillaAE", conf={"seq_len": 12, "n_features": 2}
@@ -197,6 +201,7 @@ class TestDruidTrainerUDF(unittest.TestCase):
                 ml_pipelines={
                     "pipeline1": MLPipelineConf(
                         pipeline_id="pipeline1",
+                        metrics=["failed", "degraded"],
                         numalogic_conf=NumalogicConf(
                             model=ModelInfo(
                                 name="VanillaAE", conf={"seq_len": 12, "n_features": 2}
@@ -238,6 +243,7 @@ class TestDruidTrainerUDF(unittest.TestCase):
                 ml_pipelines={
                     "pipeline1": MLPipelineConf(
                         pipeline_id="pipeline1",
+                        metrics=["failed", "degraded"],
                         numalogic_conf=NumalogicConf(
                             model=ModelInfo(
                                 name="VanillaAE", conf={"seq_len": 12, "n_features": 2}
@@ -402,6 +408,7 @@ class TestDruidTrainerUDF(unittest.TestCase):
                     ml_pipelines={
                         "pipeline1": MLPipelineConf(
                             pipeline_id="pipeline1",
+                            metrics=["failed", "degraded"],
                             numalogic_conf=NumalogicConf(
                                 model=ModelInfo(
                                     name="VanillaAE", conf={"seq_len": 12, "n_features": 2}


### PR DESCRIPTION
Explain what this PR does.
