### PR TITLE
fix for Nonetype: None in the ERROR logs

### DIFF
--- a/numalogic/udfs/inference.py
+++ b/numalogic/udfs/inference.py
@@ -135,7 +135,7 @@ class InferenceUDF(NumalogicUDF):
             msgs = Messages(get_trainer_message(keys, _stream_conf, payload))
             if _conf.numalogic_conf.score.adjust:
                 msgs.append(get_static_thresh_message(keys, payload))
-            logger.exception("Artifact model not loaded!")
+            logger.error("Artifact model not loaded!")
             return msgs
 
         # Perform inference

--- a/numalogic/udfs/preprocess.py
+++ b/numalogic/udfs/preprocess.py
@@ -167,7 +167,7 @@ class PreprocessUDF(NumalogicUDF):
                 msgs = Messages(get_trainer_message(keys, _stream_conf, payload))
                 if _conf.numalogic_conf.score.adjust:
                     msgs.append(get_static_thresh_message(keys, payload))
-                logger.exception("Artifact model not loaded!")
+                logger.error("Artifact model not loaded!")
                 return msgs
         # Model will not be in registry
         else:


### PR DESCRIPTION
What: Observed `NoneType: None ` in preprocess and inference UDFs. Example: 
`2024-07-02 03:44:26,863 - 139658258261696 - ERROR - uuid='2a4ae443-15ab-496c-95ba-83ebc380df59' event='Artifact model not loaded!' udf_vertex='inference' config_id='serviceTraceMetrics' pipeline_id='request' metadata={'adjust_with_impact': {'timestamp': 1719891659999, 'true': 0}, 'mean_of_features': {'true': 0.23076923076923078}, 'numalogic_opex_tags': {'source': 'numalogic_metrics'}, 'tags': {'assetAlias': 'Intuit.cto.iam.iux', 'assetId': '3172803529671879897', 'env': 'prd', 'opname': 'GET /fe_logger/.env.dev.local'}} exc_info=True level='error' timestamp='2024-07-02T03:44:26.863733Z'
NoneType: None`

Why: logger.exception is usually called from the `except` block. Not logging from the except block, means there is no execution_info provided. As a result, sys_exec.info() call from logging stdlib return (None, None, None) for type, value and stackTrace of exception.

How: Either write `logger.exception` inside the except block or use `logger.error` instead. 