### PR TITLE
fix: test_mlflow_registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,8 @@ target/
 #mlflow
 /.mlruns
 *.db
+mlruns/
+mlartifacts/
 
 # Jupyter Notebook
 .ipynb_checkpoints
@@ -168,5 +170,8 @@ cython_debug/
 
 # Mac related
 *.DS_Store
+
+# vscode
+.vscode/
 
 .python-version

--- a/numalogic/registry/mlflow_registry.py
+++ b/numalogic/registry/mlflow_registry.py
@@ -17,6 +17,7 @@ from typing import Optional, Any
 
 import mlflow.pyfunc
 import mlflow.pytorch
+import mlflow.sklearn
 from mlflow.entities.model_registry import ModelVersion
 from mlflow.exceptions import RestException
 from mlflow.protos.databricks_pb2 import ErrorCode, RESOURCE_DOES_NOT_EXIST

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numalogic"
-version = "0.13.1"
+version = "0.13.2"
 description = "Collection of operational Machine Learning models and tools."
 authors = ["Numalogic Developers"]
 packages = [{ include = "numalogic" }]

--- a/tests/registry/_mlflow_utils.py
+++ b/tests/registry/_mlflow_utils.py
@@ -9,8 +9,12 @@ from mlflow.models.model import ModelInfo
 from mlflow.store.entities import PagedList
 from sklearn.preprocessing import StandardScaler
 from torch import tensor
+from mlflow.models import Model
 
+from numalogic.models.autoencoder.variants.vanilla import VanillaAE
 from numalogic.models.threshold import StdDevThreshold
+from numalogic.registry.mlflow_registry import CompositeModels
+from numalogic.tools.types import KeyedArtifact
 
 
 def create_model():
@@ -132,6 +136,71 @@ def mock_log_model_sklearn(*_, **__):
         utc_time_created="2022-05-23 22:35:59.557372",
         mlflow_version="2.0.1",
         signature=None,
+    )
+
+
+def mock_log_model_pyfunc(*_, **__):
+    return ModelInfo(
+        artifact_path="model",
+        flavors={
+            "pyfunc": {"model_data": "data", "pyfunc_version": "1.11.0", "code": None},
+            "python_function": {
+                "pickle_module_name": "mlflow.pyfunc.pickle_module",
+                "loader_module": "mlflow.pyfunc",
+                "python_version": "3.8.5",
+                "data": "data",
+                "env": "conda.yaml",
+            },
+        },
+        model_uri="runs:/a7c0b376530b40d7b23e6ce2081c899c/model",
+        model_uuid="a7c0b376530b40d7b23e6ce2081c899c",
+        run_id="a7c0b376530b40d7b23e6ce2081c899c",
+        saved_input_example_info=None,
+        signature_dict=None,
+        utc_time_created="2022-05-23 22:35:59.557372",
+        mlflow_version="2.0.1",
+        signature=None,
+    )
+
+
+def mock_load_model_pyfunc(*_, **__):
+    artifact_path = "model"
+    flavors = {
+        "python_function": {
+            "cloudpickle_version": "3.0.0",
+            "code": None,
+            "env": {"conda": "conda.yaml", "virtualenv": "python_env.yaml"},
+            "loader_module": "mlflow.pyfunc.model",
+            "python_model": "python_model.pkl",
+            "python_version": "3.10.14",
+            "streamable": False,
+        }
+    }
+    model_size_bytes = 8912
+    model_uuid = "ae27ecc166c94c01a4f4dccaf84ca5dc"
+    run_id = "7e85a3fa46d44e668c840f3dddc909c3"
+    utc_time_created = "2024-09-18 17:12:41.501209"
+    model = Model(
+        artifact_path=artifact_path,
+        flavors=flavors,
+        model_size_bytes=model_size_bytes,
+        model_uuid=model_uuid,
+        run_id=run_id,
+        utc_time_created=utc_time_created,
+        mlflow_version="2.16.0",
+    )
+    return mlflow.pyfunc.PyFuncModel(
+        model_meta=model,
+        model_impl=TestObject(
+            python_model=CompositeModels(
+                skeys=["model"],
+                dict_artifacts={
+                    "AE": KeyedArtifact(dkeys=["AE", "infer"], artifact=VanillaAE(10)),
+                    "scaler": KeyedArtifact(dkeys=["scaler", "infer"], artifact=StandardScaler()),
+                },
+                **{"learning_rate": 0.01},
+            )
+        ),
     )
 
 
@@ -303,6 +372,23 @@ def return_sklearn_rundata():
     )
 
 
+def return_pyfunc_rundata():
+    return Run(
+        run_info=RunInfo(
+            artifact_uri="mlflow-artifacts:/0/a7c0b376530b40d7b23e6ce2081c899c/artifacts/model",
+            end_time=None,
+            experiment_id="0",
+            lifecycle_stage="active",
+            run_id="a7c0b376530b40d7b23e6ce2081c899c",
+            run_uuid="a7c0b376530b40d7b23e6ce2081c899c",
+            start_time=1658788772612,
+            status="RUNNING",
+            user_id="lol",
+        ),
+        run_data=RunData(metrics={}, tags={}, params={}),
+    )
+
+
 def return_pytorch_rundata_dict():
     return Run(
         run_info=RunInfo(
@@ -318,3 +404,8 @@ def return_pytorch_rundata_dict():
         ),
         run_data=RunData(metrics={}, tags={}, params=[mlflow.entities.Param("lr", "0.001")]),
     )
+
+
+class TestObject(mlflow.pyfunc.PythonModel):
+    def __init__(self, python_model):
+        self.python_model = python_model

--- a/tests/registry/test_mlflow_registry.py
+++ b/tests/registry/test_mlflow_registry.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import unittest
 from contextlib import contextmanager
 from unittest.mock import patch, Mock
@@ -9,10 +10,12 @@ from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode, RES
 from mlflow.store.entities import PagedList
 from sklearn.preprocessing import StandardScaler
 
+from mlflow.models.model import ModelInfo
 from numalogic.models.autoencoder.variants import VanillaAE
 from numalogic.registry import MLflowRegistry, ArtifactData, LocalLRUCache
+
+
 from numalogic.registry.mlflow_registry import ModelStage
-from numalogic.tools.exceptions import ModelVersionError
 from tests.registry._mlflow_utils import (
     model_sklearn,
     create_model,
@@ -26,7 +29,7 @@ from tests.registry._mlflow_utils import (
     mock_list_of_model_version,
     mock_list_of_model_version2,
     return_sklearn_rundata,
-    mock_get_model_version_obj,
+    mock_get_model_version_obj
 )
 
 TRACKING_URI = "http://0.0.0.0:5009"
@@ -53,6 +56,7 @@ class TestMLflow(unittest.TestCase):
         key = MLflowRegistry.construct_key(skeys, dkeys)
         self.assertEqual("model_:nnet::error1", key)
 
+
     @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.log_param", mock_log_state_dict)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
@@ -70,27 +74,35 @@ class TestMLflow(unittest.TestCase):
         mock_status = "READY"
         self.assertEqual(mock_status, status.status)
 
+
     @patch("mlflow.sklearn.log_model", mock_log_model_sklearn)
+    @patch("mlflow.log_param", mock_log_state_dict)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_sklearn_rundata())))
     @patch("mlflow.active_run", Mock(return_value=return_sklearn_rundata()))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
-    @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
+    @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version)
     def test_save_model_sklearn(self):
         model = self.model_sklearn
         ml = MLflowRegistry(TRACKING_URI)
         skeys = self.skeys
         dkeys = self.dkeys
-        status = ml.save(skeys=skeys, dkeys=dkeys, artifact=model, artifact_type="sklearn")
+        status = ml.save(skeys=skeys, 
+                         dkeys=dkeys, 
+                         artifact=model, 
+                         artifact_type="sklearn")
+        
         mock_status = "READY"
         self.assertEqual(mock_status, status.status)
 
-    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch())
+
+    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
-    @patch("mlflow.log_params", {"lr": 0.01})
+    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate",0.01)])))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
+    @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.pytorch.load_model", Mock(return_value=VanillaAE(10)))
     @patch("mlflow.tracking.MlflowClient.get_run", Mock(return_value=return_pytorch_rundata_dict()))
     def test_load_model_when_pytorch_model_exist1(self):
@@ -98,16 +110,23 @@ class TestMLflow(unittest.TestCase):
         ml = MLflowRegistry(TRACKING_URI)
         skeys = self.skeys
         dkeys = self.dkeys
-        ml.save(skeys=skeys, dkeys=dkeys, artifact=model, **{"lr": 0.01}, artifact_type="pytorch")
+        ml.save(skeys=skeys, 
+                dkeys=dkeys, 
+                artifact=model, 
+                **{"lr": 0.01}, 
+                artifact_type="pytorch")
         data = ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch")
         self.assertIsNotNone(data.metadata)
         self.assertIsInstance(data.artifact, VanillaAE)
+        
 
-    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch())
+
+    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
+    @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.pytorch.load_model", Mock(return_value=VanillaAE(10)))
     @patch("mlflow.tracking.MlflowClient.get_run", Mock(return_value=return_empty_rundata()))
     def test_load_model_when_pytorch_model_exist2(self):
@@ -115,7 +134,10 @@ class TestMLflow(unittest.TestCase):
         ml = MLflowRegistry(TRACKING_URI, models_to_retain=2)
         skeys = self.skeys
         dkeys = self.dkeys
-        ml.save(skeys=skeys, dkeys=dkeys, artifact=model, artifact_type="pytorch")
+        ml.save(skeys=skeys, 
+                dkeys=dkeys, 
+                artifact=model, 
+                artifact_type="pytorch")
         data = ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch")
         self.assertEqual(data.metadata, {})
         self.assertIsInstance(data.artifact, VanillaAE)
@@ -147,12 +169,15 @@ class TestMLflow(unittest.TestCase):
         self.assertIsInstance(data.artifact, StandardScaler)
         self.assertEqual(data.metadata, {})
 
-    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch())
+
+
+    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_empty_rundata())))
     @patch("mlflow.active_run", Mock(return_value=return_empty_rundata()))
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_model_version", mock_get_model_version_obj)
+    @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
     @patch("mlflow.pytorch.load_model", Mock(return_value=VanillaAE(10)))
     @patch("mlflow.tracking.MlflowClient.get_run", Mock(return_value=return_empty_rundata()))
     def test_load_model_with_version(self):
@@ -164,6 +189,8 @@ class TestMLflow(unittest.TestCase):
         data = ml.load(skeys=skeys, dkeys=dkeys, version="5", latest=False, artifact_type="pytorch")
         self.assertIsInstance(data.artifact, VanillaAE)
         self.assertEqual(data.metadata, {})
+
+
 
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
@@ -177,12 +204,17 @@ class TestMLflow(unittest.TestCase):
         ml = MLflowRegistry(TRACKING_URI, model_stage=ModelStage.STAGE)
         skeys = self.skeys
         dkeys = self.dkeys
-        ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch")
-        self.assertRaises(ModelVersionError)
+        with self.assertLogs(level="ERROR") as log:
+            result = ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch")
+        self.assertIsNone(result)  # Ensure the result is None
+        self.assertTrue(any("No Model found" in message for message in log.output))  # Check that the expected log was made
+
+
+
 
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
-    @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version())
+    @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
     @patch("mlflow.pytorch.load_model", Mock(return_value=VanillaAE(10)))
     @patch("mlflow.tracking.MlflowClient.get_run", Mock(return_value=return_empty_rundata()))
     def test_both_version_latest_model_with_version(self):
@@ -191,6 +223,7 @@ class TestMLflow(unittest.TestCase):
         dkeys = self.dkeys
         with self.assertRaises(ValueError):
             ml.load(skeys=skeys, dkeys=dkeys, latest=False, artifact_type="pytorch")
+            
 
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
@@ -247,6 +280,8 @@ class TestMLflow(unittest.TestCase):
             ml.load(skeys=fake_skeys, dkeys=fake_dkeys)
             self.assertTrue(log.output)
 
+
+
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
     @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
@@ -254,7 +289,7 @@ class TestMLflow(unittest.TestCase):
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
-    @patch("mlflow.tracking.MlflowClient.delete_model_version", None)
+    @patch("mlflow.tracking.MlflowClient.delete_model_version", Mock(return_value=None))
     @patch("mlflow.pytorch.load_model", Mock(side_effect=RuntimeError))
     def test_delete_model_when_model_exist(self):
         model = self.model
@@ -321,12 +356,15 @@ class TestMLflow(unittest.TestCase):
         dkeys = self.dkeys
         self.assertIsNone(ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch"))
 
-    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch())
+
+
+    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
-    @patch("mlflow.log_params", {"lr": 0.01})
+    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate",0.01)])))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
+    @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.pytorch.load_model", Mock(return_value=VanillaAE(10)))
     @patch("mlflow.tracking.MlflowClient.get_run", Mock(return_value=return_pytorch_rundata_dict()))
     def test_is_model_stale_true(self):
@@ -342,12 +380,14 @@ class TestMLflow(unittest.TestCase):
         data = ml.load(skeys=self.skeys, dkeys=self.dkeys, artifact_type="pytorch")
         self.assertTrue(ml.is_artifact_stale(data, 12))
 
-    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch())
+
+    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
-    @patch("mlflow.log_params", {"lr": 0.01})
+    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate",0.01)])))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
+    @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.pytorch.load_model", Mock(return_value=VanillaAE(10)))
     @patch("mlflow.tracking.MlflowClient.get_run", Mock(return_value=return_pytorch_rundata_dict()))
     def test_is_model_stale_false(self):
@@ -381,10 +421,10 @@ class TestMLflow(unittest.TestCase):
         self.assertIsNotNone(registry._load_from_cache("key"))
         self.assertIsNotNone(registry._clear_cache("key"))
 
-    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch())
+
+
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
-    @patch("mlflow.log_params", {"lr": 0.01})
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
     @patch("mlflow.pytorch.load_model", Mock(return_value=VanillaAE(10)))
@@ -392,18 +432,10 @@ class TestMLflow(unittest.TestCase):
     def test_cache_loading(self):
         cache_registry = LocalLRUCache(ttl=50000)
         ml = MLflowRegistry(TRACKING_URI, cache_registry=cache_registry)
-        ml.save(
-            skeys=self.skeys,
-            dkeys=self.dkeys,
-            artifact=self.model,
-            **{"lr": 0.01},
-            artifact_type="pytorch",
-        )
         ml.load(skeys=self.skeys, dkeys=self.dkeys, artifact_type="pytorch")
         key = MLflowRegistry.construct_key(self.skeys, self.dkeys)
         self.assertIsNotNone(ml._load_from_cache(key))
-        data = ml.load(skeys=self.skeys, dkeys=self.dkeys, artifact_type="pytorch")
-        self.assertIsNotNone(data)
+
 
 
 if __name__ == "__main__":

--- a/tests/registry/test_mlflow_registry.py
+++ b/tests/registry/test_mlflow_registry.py
@@ -10,7 +10,6 @@ from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode, RES
 from mlflow.store.entities import PagedList
 from sklearn.preprocessing import StandardScaler
 
-from mlflow.models.model import ModelInfo
 from numalogic.models.autoencoder.variants import VanillaAE
 from numalogic.registry import MLflowRegistry, ArtifactData, LocalLRUCache
 
@@ -29,7 +28,7 @@ from tests.registry._mlflow_utils import (
     mock_list_of_model_version,
     mock_list_of_model_version2,
     return_sklearn_rundata,
-    mock_get_model_version_obj
+    mock_get_model_version_obj,
 )
 
 TRACKING_URI = "http://0.0.0.0:5009"
@@ -56,7 +55,6 @@ class TestMLflow(unittest.TestCase):
         key = MLflowRegistry.construct_key(skeys, dkeys)
         self.assertEqual("model_:nnet::error1", key)
 
-
     @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.log_param", mock_log_state_dict)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
@@ -74,7 +72,6 @@ class TestMLflow(unittest.TestCase):
         mock_status = "READY"
         self.assertEqual(mock_status, status.status)
 
-
     @patch("mlflow.sklearn.log_model", mock_log_model_sklearn)
     @patch("mlflow.log_param", mock_log_state_dict)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_sklearn_rundata())))
@@ -87,19 +84,15 @@ class TestMLflow(unittest.TestCase):
         ml = MLflowRegistry(TRACKING_URI)
         skeys = self.skeys
         dkeys = self.dkeys
-        status = ml.save(skeys=skeys, 
-                         dkeys=dkeys, 
-                         artifact=model, 
-                         artifact_type="sklearn")
-        
+        status = ml.save(skeys=skeys, dkeys=dkeys, artifact=model, artifact_type="sklearn")
+
         mock_status = "READY"
         self.assertEqual(mock_status, status.status)
-
 
     @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
-    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate",0.01)])))
+    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate", 0.01)])))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
@@ -110,16 +103,10 @@ class TestMLflow(unittest.TestCase):
         ml = MLflowRegistry(TRACKING_URI)
         skeys = self.skeys
         dkeys = self.dkeys
-        ml.save(skeys=skeys, 
-                dkeys=dkeys, 
-                artifact=model, 
-                **{"lr": 0.01}, 
-                artifact_type="pytorch")
+        ml.save(skeys=skeys, dkeys=dkeys, artifact=model, **{"lr": 0.01}, artifact_type="pytorch")
         data = ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch")
         self.assertIsNotNone(data.metadata)
         self.assertIsInstance(data.artifact, VanillaAE)
-        
-
 
     @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
@@ -134,10 +121,7 @@ class TestMLflow(unittest.TestCase):
         ml = MLflowRegistry(TRACKING_URI, models_to_retain=2)
         skeys = self.skeys
         dkeys = self.dkeys
-        ml.save(skeys=skeys, 
-                dkeys=dkeys, 
-                artifact=model, 
-                artifact_type="pytorch")
+        ml.save(skeys=skeys, dkeys=dkeys, artifact=model, artifact_type="pytorch")
         data = ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch")
         self.assertEqual(data.metadata, {})
         self.assertIsInstance(data.artifact, VanillaAE)
@@ -169,8 +153,6 @@ class TestMLflow(unittest.TestCase):
         self.assertIsInstance(data.artifact, StandardScaler)
         self.assertEqual(data.metadata, {})
 
-
-
     @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_empty_rundata())))
     @patch("mlflow.active_run", Mock(return_value=return_empty_rundata()))
@@ -190,8 +172,6 @@ class TestMLflow(unittest.TestCase):
         self.assertIsInstance(data.artifact, VanillaAE)
         self.assertEqual(data.metadata, {})
 
-
-
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch(
@@ -207,10 +187,9 @@ class TestMLflow(unittest.TestCase):
         with self.assertLogs(level="ERROR") as log:
             result = ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch")
         self.assertIsNone(result)  # Ensure the result is None
-        self.assertTrue(any("No Model found" in message for message in log.output))  # Check that the expected log was made
-
-
-
+        self.assertTrue(
+            any("No Model found" in message for message in log.output)
+        )  # Check that the expected log was made
 
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
@@ -223,7 +202,6 @@ class TestMLflow(unittest.TestCase):
         dkeys = self.dkeys
         with self.assertRaises(ValueError):
             ml.load(skeys=skeys, dkeys=dkeys, latest=False, artifact_type="pytorch")
-            
 
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
@@ -279,8 +257,6 @@ class TestMLflow(unittest.TestCase):
         with self.assertLogs(level="ERROR") as log:
             ml.load(skeys=fake_skeys, dkeys=fake_dkeys)
             self.assertTrue(log.output)
-
-
 
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
@@ -356,12 +332,10 @@ class TestMLflow(unittest.TestCase):
         dkeys = self.dkeys
         self.assertIsNone(ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch"))
 
-
-
     @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
-    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate",0.01)])))
+    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate", 0.01)])))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
@@ -380,11 +354,10 @@ class TestMLflow(unittest.TestCase):
         data = ml.load(skeys=self.skeys, dkeys=self.dkeys, artifact_type="pytorch")
         self.assertTrue(ml.is_artifact_stale(data, 12))
 
-
     @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
-    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate",0.01)])))
+    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate", 0.01)])))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
@@ -421,8 +394,6 @@ class TestMLflow(unittest.TestCase):
         self.assertIsNotNone(registry._load_from_cache("key"))
         self.assertIsNotNone(registry._clear_cache("key"))
 
-
-
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
@@ -435,7 +406,6 @@ class TestMLflow(unittest.TestCase):
         ml.load(skeys=self.skeys, dkeys=self.dkeys, artifact_type="pytorch")
         key = MLflowRegistry.construct_key(self.skeys, self.dkeys)
         self.assertIsNotNone(ml._load_from_cache(key))
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There existed errors in test logs while test cases still passed. One example is the ConnectionError due to not mocking mlflow function calls properly. 

Fixed through modifying a few syntax for patch mock calls. The test cases should pass with no logging errors now.