### PR TITLE
fix: test cases mlflow registry

### DIFF
--- a/numalogic/registry/mlflow_registry.py
+++ b/numalogic/registry/mlflow_registry.py
@@ -17,6 +17,7 @@ from typing import Optional, Any
 
 import mlflow.pyfunc
 import mlflow.pytorch
+import mlflow.sklearn
 from mlflow.entities.model_registry import ModelVersion
 from mlflow.exceptions import RestException
 from mlflow.protos.databricks_pb2 import ErrorCode, RESOURCE_DOES_NOT_EXIST

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numalogic"
-version = "0.13.1"
+version = "0.13.2"
 description = "Collection of operational Machine Learning models and tools."
 authors = ["Numalogic Developers"]
 packages = [{ include = "numalogic" }]

--- a/tests/registry/test_mlflow_registry.py
+++ b/tests/registry/test_mlflow_registry.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import unittest
 from contextlib import contextmanager
 from unittest.mock import patch, Mock
@@ -9,10 +10,12 @@ from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode, RES
 from mlflow.store.entities import PagedList
 from sklearn.preprocessing import StandardScaler
 
+from mlflow.models.model import ModelInfo
 from numalogic.models.autoencoder.variants import VanillaAE
 from numalogic.registry import MLflowRegistry, ArtifactData, LocalLRUCache
+
+
 from numalogic.registry.mlflow_registry import ModelStage
-from numalogic.tools.exceptions import ModelVersionError
 from tests.registry._mlflow_utils import (
     model_sklearn,
     create_model,
@@ -26,7 +29,7 @@ from tests.registry._mlflow_utils import (
     mock_list_of_model_version,
     mock_list_of_model_version2,
     return_sklearn_rundata,
-    mock_get_model_version_obj,
+    mock_get_model_version_obj
 )
 
 TRACKING_URI = "http://0.0.0.0:5009"
@@ -53,6 +56,7 @@ class TestMLflow(unittest.TestCase):
         key = MLflowRegistry.construct_key(skeys, dkeys)
         self.assertEqual("model_:nnet::error1", key)
 
+
     @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.log_param", mock_log_state_dict)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
@@ -70,27 +74,35 @@ class TestMLflow(unittest.TestCase):
         mock_status = "READY"
         self.assertEqual(mock_status, status.status)
 
+
     @patch("mlflow.sklearn.log_model", mock_log_model_sklearn)
+    @patch("mlflow.log_param", mock_log_state_dict)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_sklearn_rundata())))
     @patch("mlflow.active_run", Mock(return_value=return_sklearn_rundata()))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
-    @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
+    @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version)
     def test_save_model_sklearn(self):
         model = self.model_sklearn
         ml = MLflowRegistry(TRACKING_URI)
         skeys = self.skeys
         dkeys = self.dkeys
-        status = ml.save(skeys=skeys, dkeys=dkeys, artifact=model, artifact_type="sklearn")
+        status = ml.save(skeys=skeys, 
+                         dkeys=dkeys, 
+                         artifact=model, 
+                         artifact_type="sklearn")
+        
         mock_status = "READY"
         self.assertEqual(mock_status, status.status)
 
-    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch())
+
+    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
-    @patch("mlflow.log_params", {"lr": 0.01})
+    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate",0.01)])))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
+    @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.pytorch.load_model", Mock(return_value=VanillaAE(10)))
     @patch("mlflow.tracking.MlflowClient.get_run", Mock(return_value=return_pytorch_rundata_dict()))
     def test_load_model_when_pytorch_model_exist1(self):
@@ -98,16 +110,23 @@ class TestMLflow(unittest.TestCase):
         ml = MLflowRegistry(TRACKING_URI)
         skeys = self.skeys
         dkeys = self.dkeys
-        ml.save(skeys=skeys, dkeys=dkeys, artifact=model, **{"lr": 0.01}, artifact_type="pytorch")
+        ml.save(skeys=skeys, 
+                dkeys=dkeys, 
+                artifact=model, 
+                **{"lr": 0.01}, 
+                artifact_type="pytorch")
         data = ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch")
         self.assertIsNotNone(data.metadata)
         self.assertIsInstance(data.artifact, VanillaAE)
+        
 
-    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch())
+
+    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
+    @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.pytorch.load_model", Mock(return_value=VanillaAE(10)))
     @patch("mlflow.tracking.MlflowClient.get_run", Mock(return_value=return_empty_rundata()))
     def test_load_model_when_pytorch_model_exist2(self):
@@ -115,7 +134,10 @@ class TestMLflow(unittest.TestCase):
         ml = MLflowRegistry(TRACKING_URI, models_to_retain=2)
         skeys = self.skeys
         dkeys = self.dkeys
-        ml.save(skeys=skeys, dkeys=dkeys, artifact=model, artifact_type="pytorch")
+        ml.save(skeys=skeys, 
+                dkeys=dkeys, 
+                artifact=model, 
+                artifact_type="pytorch")
         data = ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch")
         self.assertEqual(data.metadata, {})
         self.assertIsInstance(data.artifact, VanillaAE)
@@ -147,12 +169,15 @@ class TestMLflow(unittest.TestCase):
         self.assertIsInstance(data.artifact, StandardScaler)
         self.assertEqual(data.metadata, {})
 
-    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch())
+
+
+    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_empty_rundata())))
     @patch("mlflow.active_run", Mock(return_value=return_empty_rundata()))
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_model_version", mock_get_model_version_obj)
+    @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
     @patch("mlflow.pytorch.load_model", Mock(return_value=VanillaAE(10)))
     @patch("mlflow.tracking.MlflowClient.get_run", Mock(return_value=return_empty_rundata()))
     def test_load_model_with_version(self):
@@ -164,6 +189,8 @@ class TestMLflow(unittest.TestCase):
         data = ml.load(skeys=skeys, dkeys=dkeys, version="5", latest=False, artifact_type="pytorch")
         self.assertIsInstance(data.artifact, VanillaAE)
         self.assertEqual(data.metadata, {})
+
+
 
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
@@ -177,12 +204,17 @@ class TestMLflow(unittest.TestCase):
         ml = MLflowRegistry(TRACKING_URI, model_stage=ModelStage.STAGE)
         skeys = self.skeys
         dkeys = self.dkeys
-        ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch")
-        self.assertRaises(ModelVersionError)
+        with self.assertLogs(level="ERROR") as log:
+            result = ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch")
+        self.assertIsNone(result)  # Ensure the result is None
+        self.assertTrue(any("No Model found" in message for message in log.output))  # Check that the expected log was made
+
+
+
 
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
-    @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version())
+    @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
     @patch("mlflow.pytorch.load_model", Mock(return_value=VanillaAE(10)))
     @patch("mlflow.tracking.MlflowClient.get_run", Mock(return_value=return_empty_rundata()))
     def test_both_version_latest_model_with_version(self):
@@ -191,6 +223,7 @@ class TestMLflow(unittest.TestCase):
         dkeys = self.dkeys
         with self.assertRaises(ValueError):
             ml.load(skeys=skeys, dkeys=dkeys, latest=False, artifact_type="pytorch")
+            
 
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
@@ -247,6 +280,8 @@ class TestMLflow(unittest.TestCase):
             ml.load(skeys=fake_skeys, dkeys=fake_dkeys)
             self.assertTrue(log.output)
 
+
+
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
     @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
@@ -254,7 +289,7 @@ class TestMLflow(unittest.TestCase):
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
-    @patch("mlflow.tracking.MlflowClient.delete_model_version", None)
+    @patch("mlflow.tracking.MlflowClient.delete_model_version", Mock(return_value=None))
     @patch("mlflow.pytorch.load_model", Mock(side_effect=RuntimeError))
     def test_delete_model_when_model_exist(self):
         model = self.model
@@ -321,12 +356,15 @@ class TestMLflow(unittest.TestCase):
         dkeys = self.dkeys
         self.assertIsNone(ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch"))
 
-    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch())
+
+
+    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
-    @patch("mlflow.log_params", {"lr": 0.01})
+    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate",0.01)])))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
+    @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.pytorch.load_model", Mock(return_value=VanillaAE(10)))
     @patch("mlflow.tracking.MlflowClient.get_run", Mock(return_value=return_pytorch_rundata_dict()))
     def test_is_model_stale_true(self):
@@ -342,12 +380,14 @@ class TestMLflow(unittest.TestCase):
         data = ml.load(skeys=self.skeys, dkeys=self.dkeys, artifact_type="pytorch")
         self.assertTrue(ml.is_artifact_stale(data, 12))
 
-    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch())
+
+    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
-    @patch("mlflow.log_params", {"lr": 0.01})
+    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate",0.01)])))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
+    @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.pytorch.load_model", Mock(return_value=VanillaAE(10)))
     @patch("mlflow.tracking.MlflowClient.get_run", Mock(return_value=return_pytorch_rundata_dict()))
     def test_is_model_stale_false(self):
@@ -381,10 +421,10 @@ class TestMLflow(unittest.TestCase):
         self.assertIsNotNone(registry._load_from_cache("key"))
         self.assertIsNotNone(registry._clear_cache("key"))
 
-    @patch("mlflow.pytorch.log_model", mock_log_model_pytorch())
+
+
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
-    @patch("mlflow.log_params", {"lr": 0.01})
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
     @patch("mlflow.pytorch.load_model", Mock(return_value=VanillaAE(10)))
@@ -392,18 +432,10 @@ class TestMLflow(unittest.TestCase):
     def test_cache_loading(self):
         cache_registry = LocalLRUCache(ttl=50000)
         ml = MLflowRegistry(TRACKING_URI, cache_registry=cache_registry)
-        ml.save(
-            skeys=self.skeys,
-            dkeys=self.dkeys,
-            artifact=self.model,
-            **{"lr": 0.01},
-            artifact_type="pytorch",
-        )
         ml.load(skeys=self.skeys, dkeys=self.dkeys, artifact_type="pytorch")
         key = MLflowRegistry.construct_key(self.skeys, self.dkeys)
         self.assertIsNotNone(ml._load_from_cache(key))
-        data = ml.load(skeys=self.skeys, dkeys=self.dkeys, artifact_type="pytorch")
-        self.assertIsNotNone(data)
+
 
 
 if __name__ == "__main__":

--- a/tests/registry/test_mlflow_registry.py
+++ b/tests/registry/test_mlflow_registry.py
@@ -10,7 +10,6 @@ from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode, RES
 from mlflow.store.entities import PagedList
 from sklearn.preprocessing import StandardScaler
 
-from mlflow.models.model import ModelInfo
 from numalogic.models.autoencoder.variants import VanillaAE
 from numalogic.registry import MLflowRegistry, ArtifactData, LocalLRUCache
 
@@ -29,7 +28,7 @@ from tests.registry._mlflow_utils import (
     mock_list_of_model_version,
     mock_list_of_model_version2,
     return_sklearn_rundata,
-    mock_get_model_version_obj
+    mock_get_model_version_obj,
 )
 
 TRACKING_URI = "http://0.0.0.0:5009"
@@ -56,7 +55,6 @@ class TestMLflow(unittest.TestCase):
         key = MLflowRegistry.construct_key(skeys, dkeys)
         self.assertEqual("model_:nnet::error1", key)
 
-
     @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.log_param", mock_log_state_dict)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
@@ -74,7 +72,6 @@ class TestMLflow(unittest.TestCase):
         mock_status = "READY"
         self.assertEqual(mock_status, status.status)
 
-
     @patch("mlflow.sklearn.log_model", mock_log_model_sklearn)
     @patch("mlflow.log_param", mock_log_state_dict)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_sklearn_rundata())))
@@ -87,19 +84,15 @@ class TestMLflow(unittest.TestCase):
         ml = MLflowRegistry(TRACKING_URI)
         skeys = self.skeys
         dkeys = self.dkeys
-        status = ml.save(skeys=skeys, 
-                         dkeys=dkeys, 
-                         artifact=model, 
-                         artifact_type="sklearn")
-        
+        status = ml.save(skeys=skeys, dkeys=dkeys, artifact=model, artifact_type="sklearn")
+
         mock_status = "READY"
         self.assertEqual(mock_status, status.status)
-
 
     @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
-    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate",0.01)])))
+    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate", 0.01)])))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
@@ -110,16 +103,10 @@ class TestMLflow(unittest.TestCase):
         ml = MLflowRegistry(TRACKING_URI)
         skeys = self.skeys
         dkeys = self.dkeys
-        ml.save(skeys=skeys, 
-                dkeys=dkeys, 
-                artifact=model, 
-                **{"lr": 0.01}, 
-                artifact_type="pytorch")
+        ml.save(skeys=skeys, dkeys=dkeys, artifact=model, **{"lr": 0.01}, artifact_type="pytorch")
         data = ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch")
         self.assertIsNotNone(data.metadata)
         self.assertIsInstance(data.artifact, VanillaAE)
-        
-
 
     @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
@@ -134,10 +121,7 @@ class TestMLflow(unittest.TestCase):
         ml = MLflowRegistry(TRACKING_URI, models_to_retain=2)
         skeys = self.skeys
         dkeys = self.dkeys
-        ml.save(skeys=skeys, 
-                dkeys=dkeys, 
-                artifact=model, 
-                artifact_type="pytorch")
+        ml.save(skeys=skeys, dkeys=dkeys, artifact=model, artifact_type="pytorch")
         data = ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch")
         self.assertEqual(data.metadata, {})
         self.assertIsInstance(data.artifact, VanillaAE)
@@ -169,8 +153,6 @@ class TestMLflow(unittest.TestCase):
         self.assertIsInstance(data.artifact, StandardScaler)
         self.assertEqual(data.metadata, {})
 
-
-
     @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_empty_rundata())))
     @patch("mlflow.active_run", Mock(return_value=return_empty_rundata()))
@@ -190,8 +172,6 @@ class TestMLflow(unittest.TestCase):
         self.assertIsInstance(data.artifact, VanillaAE)
         self.assertEqual(data.metadata, {})
 
-
-
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch(
@@ -207,10 +187,9 @@ class TestMLflow(unittest.TestCase):
         with self.assertLogs(level="ERROR") as log:
             result = ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch")
         self.assertIsNone(result)  # Ensure the result is None
-        self.assertTrue(any("No Model found" in message for message in log.output))  # Check that the expected log was made
-
-
-
+        self.assertTrue(
+            any("No Model found" in message for message in log.output)
+        )  # Check that the expected log was made
 
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
@@ -223,7 +202,6 @@ class TestMLflow(unittest.TestCase):
         dkeys = self.dkeys
         with self.assertRaises(ValueError):
             ml.load(skeys=skeys, dkeys=dkeys, latest=False, artifact_type="pytorch")
-            
 
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
@@ -279,8 +257,6 @@ class TestMLflow(unittest.TestCase):
         with self.assertLogs(level="ERROR") as log:
             ml.load(skeys=fake_skeys, dkeys=fake_dkeys)
             self.assertTrue(log.output)
-
-
 
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
@@ -356,12 +332,10 @@ class TestMLflow(unittest.TestCase):
         dkeys = self.dkeys
         self.assertIsNone(ml.load(skeys=skeys, dkeys=dkeys, artifact_type="pytorch"))
 
-
-
     @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
-    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate",0.01)])))
+    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate", 0.01)])))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
@@ -380,11 +354,10 @@ class TestMLflow(unittest.TestCase):
         data = ml.load(skeys=self.skeys, dkeys=self.dkeys, artifact_type="pytorch")
         self.assertTrue(ml.is_artifact_stale(data, 12))
 
-
     @patch("mlflow.pytorch.log_model", mock_log_model_pytorch)
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
-    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate",0.01)])))
+    @patch("mlflow.log_params", Mock(return_value=OrderedDict([("learning_rate", 0.01)])))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
     @patch("mlflow.tracking.MlflowClient.get_latest_versions", mock_get_model_version)
     @patch("mlflow.tracking.MlflowClient.search_model_versions", mock_list_of_model_version2)
@@ -421,8 +394,6 @@ class TestMLflow(unittest.TestCase):
         self.assertIsNotNone(registry._load_from_cache("key"))
         self.assertIsNotNone(registry._clear_cache("key"))
 
-
-
     @patch("mlflow.start_run", Mock(return_value=ActiveRun(return_pytorch_rundata_dict())))
     @patch("mlflow.active_run", Mock(return_value=return_pytorch_rundata_dict()))
     @patch("mlflow.tracking.MlflowClient.transition_model_version_stage", mock_transition_stage)
@@ -435,7 +406,6 @@ class TestMLflow(unittest.TestCase):
         ml.load(skeys=self.skeys, dkeys=self.dkeys, artifact_type="pytorch")
         key = MLflowRegistry.construct_key(self.skeys, self.dkeys)
         self.assertIsNotNone(ml._load_from_cache(key))
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There existed errors in test logs while test cases still passed. One example is the ConnectionError due to not mocking mlflow function calls properly.

Fixed through modifying a few syntax for patch mock calls. The test cases should pass with no logging errors now.